### PR TITLE
Improve: prevent realloc every time you follow the key ascending set

### DIFF
--- a/sched.c
+++ b/sched.c
@@ -457,9 +457,9 @@ int co_setspecific(int key, const void *value)
         return EINVAL;
     }
     if(current->spec_num <= key) {
-        current->specific = realloc(current->specific, (key+1)*sizeof(void *));
-        memset(current->specific + current->spec_num, 0, (key+1-current->spec_num)*sizeof(void *));
-        current->spec_num = key+1;
+        current->specific = realloc(current->specific, co_specific_num*sizeof(void *));
+        memset(current->specific + current->spec_num, 0, (co_specific_num-current->spec_num)*sizeof(void *));
+        current->spec_num = co_specific_num;
     }
     current->specific[key] = (void *)value;
     return 0;


### PR DESCRIPTION
考虑到局部存储的key不会太多，所以多消耗一些内存以免每次按照key升序set value的时候都要realloc